### PR TITLE
Update GitHub Actions runner to depot-ubuntu-24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   linting:
     name: Linting
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Set up Python


### PR DESCRIPTION
## Summary

Migrate the CI linting job runner from `ubuntu-latest` to `depot-ubuntu-24.04` to align with the organization's standard runner image.

## Review & Testing Checklist for Human

- [ ] Verify that `depot-ubuntu-24.04` runners are available and configured for this repository in Depot
- [ ] Confirm the workflow runs successfully after merge by checking a CI run

