### PR TITLE
fix: append L suffix to timestamp filter for Exact API compatibility

### DIFF
--- a/tap_exact/client.py
+++ b/tap_exact/client.py
@@ -199,7 +199,7 @@ class ExactSyncStream(ExactBulkStream):
         if self.select:
             params["$select"] = self.select
         starting_timestamp = self.get_starting_replication_key_value(context)
-        params["$filter"] = f"Timestamp gt {starting_timestamp if type(starting_timestamp) is int else 1}"
+        params["$filter"] = f"Timestamp gt {starting_timestamp if type(starting_timestamp) is int else 1}L"
         if next_page_token:
             params["$skiptoken"] = next_page_token
         return params


### PR DESCRIPTION
## Summary

- Appends `L` suffix to the timestamp value in the OData `\$filter` parameter (e.g. `Timestamp gt 12345L`)
- The Exact API requires this suffix to treat the value as a long integer type in OData filter expressions

## Test plan

- [ ] Run a sync stream and verify the timestamp filter is correctly formatted with the `L` suffix
- [ ] Confirm incremental replication still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)